### PR TITLE
Specialize __foldl__ for Tuple

### DIFF
--- a/examples/primes.jl
+++ b/examples/primes.jl
@@ -10,7 +10,7 @@ end                               # hide
 using Transducers
 
 sieve(xf, x) =
-    if mapfoldl(xf, right, (x,), init=nothing) === nothing
+    if isnothing(mapfoldl(xf, right, (x,), init=nothing))
         nothing, xf
     else
         x, xf |> Filter(n -> n % x != 0)

--- a/src/core.jl
+++ b/src/core.jl
@@ -926,7 +926,7 @@ Base.show(io::IO, init::CopyInit) = _default_show(io, init)
 @inline foldlargs(op, x) = x
 @inline foldlargs(op, x1, x2, xs...) =
     foldlargs(op,
-              @return_if_reduced(op(x1, x2)),
+              @next(op, x1, x2),
               xs...)
 
 """

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -146,6 +146,9 @@ end
     return complete(rf, val)
 end
 
+__foldl__(rf, init, coll::Tuple) =
+    complete(rf, @return_if_reduced foldlargs(rf, init, coll...))
+
 # TODO: use IndexStyle
 @inline function __foldl__(rf, init, arr::Union{AbstractArray, Broadcasted})
     isempty(arr) && return complete(rf, init)

--- a/test/test_inference.jl
+++ b/test/test_inference.jl
@@ -54,12 +54,22 @@ end
     end
 end
 
+hasnothing(xs) = foreach(Map(identity), xs) do x
+    if x === nothing
+        return reduced(Val(true))
+    end
+end |> ifunreduced() do _
+    Val(false)
+end
+
 @testset "foreach" begin
     @testset for xs in collections
         @test_inferred foreach(constant(nothing), Map(exp), xs)
         @test_inferred foreach(constant(nothing), Map(exp) |> Filter(x -> x > 0),
                                xs)
     end
+    @test (@inferred hasnothing((1, 2, 3))) === Val(false)
+    @test (@inferred hasnothing((1, nothing, 3))) === Val(true)
 end
 
 @testset "eduction" begin


### PR DESCRIPTION
There is a very strange test failure I cannot reproduce locally

```
test_examples_primes.jl: Test Failed at /home/travis/build/tkf/Transducers.jl/examples/primes.jl:27
  Expression: primes == [2, 3, 5, 7]
   Evaluated: [2, 3, 4, 5, 7] == [2, 3, 5, 7]
```

see, e.g., https://travis-ci.com/tkf/Transducers.jl/jobs/215961196#L530-L532
