### PR TITLE
Revert "Handle at-simd invariants" etc.

### DIFF
--- a/benchmark/bench_gemm.jl
+++ b/benchmark/bench_gemm.jl
@@ -5,7 +5,7 @@ using BenchmarkTools
 using LinearAlgebra
 using Referenceables: referenceable
 using Transducers
-using Transducers: @simd_if, @next!, complete, maybe_usesimd, BottomRF, SideEffect
+using Transducers: @simd_if, @next, complete, maybe_usesimd, BottomRF, SideEffect
 
 _size(x) = size.(axes(x), 1)
 _size(x, i) = size(axes(x)[i], 1)
@@ -21,7 +21,7 @@ _size(x, i) = size(axes(x)[i], 1)
             @simd_if rf for i in 1:size(A, 1)
                 c = @inbounds C[i, j]
                 a = @inbounds A[i, k]
-                @next!(rf, acc, (c, a, b))
+                acc = @next(rf, acc, (c, a, b))
             end
         end
         return complete(rf, acc)

--- a/benchmark/bench_gemm.jl
+++ b/benchmark/bench_gemm.jl
@@ -43,6 +43,7 @@ function xfmul!(C, A, B, simd=Val(false))
 
     rf = SideEffect() do (c, a, b)
         c[] = muladd(a, b, c[])
+        return  # for type stability
     end
     transduce(maybe_usesimd(BottomRF{Any}(rf), simd), nothing, CAB)
 
@@ -131,6 +132,7 @@ function fusedxfmul!(C, A, B1, B2)
         c1 = muladd(a, b1, c0)
         c2 = a^2 * b2
         c[] = c1 + c2
+        return  # for type stability
     end
 
     return C

--- a/src/core.jl
+++ b/src/core.jl
@@ -185,19 +185,6 @@ macro next(rf, state, input)
     end
 end
 
-"""
-    @next!(rf, state, input)
-
-It is expanded to
-
-```julia
-state = @next(rf, state, input)
-```
-"""
-macro next!(rf, state, input)
-    esc(:($state = $(@__MODULE__).@next($rf, $state, $input)))
-end
-
 struct NoType end
 const NOTYPE = NoType()
 const Typeish{T} = Union{Type{T}, NoType}

--- a/src/interop/blockarrays.jl
+++ b/src/interop/blockarrays.jl
@@ -43,7 +43,7 @@ end
     @inbounds for j in 1:nblocks(coll, 1)
         array = coll[Block(j, block...)]
         @simd_if rf for k in 1:blocksize(coll, 1, j)
-            @next!(rf, acc, array[k, offset...])
+            acc = @next(rf, acc, array[k, offset...])
         end
     end
     return acc

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -156,7 +156,7 @@ __foldl__(rf, init, coll::Tuple) =
     val = @next(rf, init, @inbounds arr[idxs[firstindex(idxs)]])
     @simd_if rf for k in firstindex(idxs) + 1:lastindex(idxs)
         i = @inbounds idxs[k]
-        @next!(rf, val, @inbounds arr[i])
+        val = @next(rf, val, @inbounds arr[i])
     end
     return complete(rf, val)
 end
@@ -173,7 +173,7 @@ end
         idxs = eachindex(zs.is...)
         val = @next(rf, init, _getvalues(firstindex(idxs), zs.is...))
         @simd_if rf for i in firstindex(idxs) + 1:lastindex(idxs)
-            @next!(rf, val, _getvalues(i, zs.is...))
+            val = @next(rf, val, _getvalues(i, zs.is...))
         end
         return complete(rf, val)
     end
@@ -204,7 +204,7 @@ end
     # TODO: Handle the case inner iterators are tuples.  In such case,
     # inner-most non-tuple iterators should use @simd_if.
     @simd_if rf for input in iterator
-        @next!(rf, val, (input, outer...))
+        val = @next(rf, val, (input, outer...))
     end
     return val
 end

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -366,7 +366,6 @@ end
 function Base.mapfoldl(xform::Transducer, step, itr;
                        simd::SIMDFlag = Val(false),
                        init = MissingInit())
-    check_no_ivdep(simd)
     unreduced(transduce(xform, step, init, itr; simd=simd))
 end
 
@@ -728,12 +727,10 @@ julia> foldl(Filter(isodd), 1:4, init=0.0) do state, input
 """
 function Base.foldl(step, xform::Transducer, itr;
                     kw...)
-    check_no_ivdep(; kw...)
     mapfoldl(xform, Completing(step), itr; kw...)
 end
 
-@inline function Base.foldl(step, ed::Eduction; init=MissingInit(), kwargs...)
-    check_no_ivdep(; kwargs...)
+@inline Base.foldl(step, ed::Eduction; init=MissingInit(), kwargs...) =
     if FinalType(ed.rf) === NOTYPE
         xf = Transducer(ed.rf)
         unreduced(transduce(xf, Completing(step), init, ed.coll; kwargs...))
@@ -741,7 +738,6 @@ end
         rf = reform(ed.rf, Completing(step))
         unreduced(transduce(rf, init, ed.coll; kwargs...))
     end
-end
 
 """
     foreach(eff, xf::Transducer, reducible; simd)

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -18,74 +18,23 @@ skipcomplete(rf::R_{UseSIMD}) =
 isivdep(::UseSIMD{ivdep}) where ivdep = ivdep
 isivdep(rf::Reduction) = isivdep(xform(rf))
 
-maybeignore(rf, acc) = isivdep(rf) ? nothing : acc
-
 _name_of_transducer_type(xf::UseSIMD) = prefixed_type_name(xf)
-
-findaccumulators(::Any) = []
-findaccumulators(ex::Expr) =
-    if ex.head === :macrocall && ex.args[1] === Symbol("@next!")
-        @argcheck length(ex.args) === 5
-        rf, acc, input = ex.args[3:end]
-        return Any[acc::Symbol]
-    else
-        return mapfoldl(findaccumulators, append!, ex.args; init=[])
-    end
-
-simdcompat(ivdep, acc, x) = x
-function simdcompat(ivdep, acc, ex::Expr)
-    # TODO: detect Transducers.@next etc.
-    if (
-        (ex.head === :macrocall && ex.args[1] === Symbol("@next")) ||
-        (ex.head === :call && ex.args[1] === :next)
-    )
-        error("Use `@next!` inside `@simd_if`.")
-    elseif ex.head === :macrocall && ex.args[1] === Symbol("@next!")
-        @argcheck length(ex.args) === 5
-        rf, acc′, input = ex.args[3:end]
-        if ivdep
-            # No loop-carried memory dependencies are allowed.
-            # However, to support `TeeZip`, `acc` must still be
-            # supplied:
-            return quote
-                $next($rf, $acc, $input)
-                nothing
-            end
-        else
-            @assert acc′ == acc
-            # Exclude `acc isa Reduced && return acc` part:
-            return :($acc = $next($rf, $acc, $input))
-        end
-    else
-        return Expr(ex.head, simdcompat.(ivdep, Ref(acc), ex.args)...)
-    end
-end
 
 """
     @simd_if rf for ... end
 
 Wrap `for`-loop with `@simd` if the outer most transducer of the
 reducing function `rf` is `UseSIMD`.
-
-The [`next`](@ref) must be called via `@next!` macro.  `@simd_if`
-appropriately choose to not use `result isa Reduced && return result`
-when SIMD is enabled.  It also makes sure that the state returned
-by `next` is ignored when `ivdep` is specified.
 """
 macro simd_if(rf, loop)
-    accs = findaccumulators(loop)
-    @argcheck length(accs) == 1
-    acc, = accs
-    @gensym acc0
     # Aggressively using `$` since `esc(loop)` did not work with
     # `@simd` macro.
     ex = quote
         if $rf isa $R_{$UseSIMD}
             if $isivdep($rf)
-                $acc0 = $acc  # must not change during the loop
-                $Base.@simd ivdep $(simdcompat(true, acc0, loop))
+                $Base.@simd ivdep $loop
             else
-                $Base.@simd $(simdcompat(false, acc, loop))
+                $Base.@simd $loop
             end
         else
             $loop

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -8,19 +8,6 @@ struct UseSIMD{ivdep} <: Transducer end
 outtype(::UseSIMD, intype) = intype
 next(rf::R_{UseSIMD}, result, input) = next(inner(rf), result, input)
 
-function start(rf::R_{UseSIMD{true}}, result)
-    state = start(inner(rf), result)
-    if !(state === result || is_ivdep_compat_state(state))
-        error("`simd=:ivdep` must not be used with stateful transducers")
-    end
-    return state
-end
-
-@inline is_ivdep_compat_state(::Any) = true
-@inline is_ivdep_compat_state(::PrivateState) = false
-@inline is_ivdep_compat_state(state::Union{SplitterState, JoinerState}) =
-    is_ivdep_compat_state(psresult(state))
-
 # Make sure UseSIMD is the outer-most transducer when UseSIMD is used
 # via Cat.
 skipcomplete(rf::R_{UseSIMD}) =

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -68,15 +68,7 @@ by `next` is ignored when `ivdep` is specified.
 """
 macro simd_if(rf, loop)
     accs = findaccumulators(loop)
-    if length(accs) == 0
-        error(
-            "No call of the form `@next!(rf, acc, input)` is found.\n",
-            "`@next(rf, acc, input)` and `next(rf, acc, input)` are not",
-            " supported inside `@simd_if`."
-        )
-    elseif length(accs) > 1
-        error("Multiple `@next!(rf, acc, input)` statements found.")
-    end
+    @argcheck length(accs) == 1
     acc, = accs
     @gensym acc0
     # Aggressively using `$` since `esc(loop)` did not work with

--- a/src/simd.jl
+++ b/src/simd.jl
@@ -99,20 +99,6 @@ end
 const SIMDFlag = Union{Bool, Symbol, Val{true}, Val{false}, Val{:ivdep}}
 
 """
-    check_no_ivdep(::SIMDFlag)
-    check_no_ivdep(; simd=Val(false), kwargs...)
-"""
-@inline check_no_ivdep(simd) = simd
-@inline check_no_ivdep(simd::Symbol) =
-    simd == :ivdep ? check_no_ivdep(Val(:ivdep)) : simd
-@noinline check_no_ivdep(::Val{:ivdep}) =
-    throw(ArgumentError(string(
-        "`simd=:ivdep` must not be used for generic `foldl` or `reduce`.",
-        " Please use `foreach`."
-    )))
-check_no_ivdep(; simd=Val(false), _...) = check_no_ivdep(simd)
-
-"""
     maybe_usesimd(xform, simd)
 
 Insert `UseSIMD` to `xform` if appropriate.

--- a/test/test_simd.jl
+++ b/test/test_simd.jl
@@ -51,17 +51,6 @@ end
     end
 end
 
-@testset "UX" begin
-    for err in [
-        (@test_error mapfoldl(Map(identity), +, 1:2; simd=:ivdep)),
-        (@test_error foldl(+, Map(identity), 1:2; simd=:ivdep)),
-        (@test_error foldl(+, eduction(Map(identity), 1:2); simd=:ivdep)),
-    ]
-        @test occursin("`simd=:ivdep` must not be used",
-                       sprint(showerror, err))
-    end
-end
-
 @testset "@simd_if" begin
     err = @test_error @macroexpand @simd_if rf for i in 1:1
     end

--- a/test/test_simd.jl
+++ b/test/test_simd.jl
@@ -56,12 +56,10 @@ end
         (@test_error mapfoldl(Map(identity), +, 1:2; simd=:ivdep)),
         (@test_error foldl(+, Map(identity), 1:2; simd=:ivdep)),
         (@test_error foldl(+, eduction(Map(identity), 1:2); simd=:ivdep)),
-        (@test_error foreach(identity, Count() |> Map(first), 1:2; simd=:ivdep)),
     ]
         @test occursin("`simd=:ivdep` must not be used",
                        sprint(showerror, err))
     end
-    @test foreach(identity, TeeZip(Map(inc)), 1:2; simd=:ivdep) isa Any
 end
 
 @testset "@simd_if" begin

--- a/test/test_simd.jl
+++ b/test/test_simd.jl
@@ -1,7 +1,7 @@
 module TestSIMD
 include("preamble.jl")
 
-using Transducers: UseSIMD, usesimd, Reduction, skipcomplete, R_, @simd_if
+using Transducers: UseSIMD, usesimd, Reduction, skipcomplete, R_
 
 asrf(xf) = Reduction(xf, right, Int)
 
@@ -49,20 +49,6 @@ end
         end
         @test ys == xs .+ 1.0
     end
-end
-
-@testset "@simd_if" begin
-    err = @test_error @macroexpand @simd_if rf for i in 1:1
-    end
-    @test occursin("No call of the form `@next!(rf, acc, input)` is found.",
-                   sprint(showerror, err))
-
-    err = @test_error @macroexpand @simd_if rf for i in 1:1
-        @next!(rf, acc, init)
-        @next!(rf, acc, init)
-    end
-    @test occursin("Multiple `@next!(rf, acc, input)` statements found.",
-                   sprint(showerror, err))
 end
 
 end  # module

--- a/test/test_simd.jl
+++ b/test/test_simd.jl
@@ -1,7 +1,21 @@
 module TestSIMD
 include("preamble.jl")
 
-using Transducers: UseSIMD, usesimd, Reduction, skipcomplete, R_
+using Transducers: @simd_if, UseSIMD, usesimd, Reduction, skipcomplete, R_
+
+function simd_if_demo(xf, ys, xs)
+    @inbounds @simd_if xf for i in eachindex(ys, xs)
+        ys[i] = 2 .* xs[i]
+    end
+    return ys
+end
+
+@testset "@simd_if" begin
+    xs = [1:100;] .* 1.0
+    @test simd_if_demo(Map(identity), zero(xs), xs) == 2xs
+    @test simd_if_demo(UseSIMD{false}(), zero(xs), xs) == 2xs
+    @test simd_if_demo(UseSIMD{true}(), zero(xs), xs) == 2xs
+end
 
 asrf(xf) = Reduction(xf, right, Int)
 
@@ -40,8 +54,7 @@ end
 end
 
 @testset "foreach" begin
-    # TODO: simd=:ivdep support using Referenceables.jl
-    @testset for simd in [false, true]
+    @testset for simd in [false, true, :ivdep]
         xs = [1:100;]
         ys = zeros(100)
         foreach(Zip(Count(), Map(x -> x + 1.0)), xs; simd=simd) do (i, x)


### PR DESCRIPTION
`simd = :ivdep` with stateful transducers should be fine as long as the states are immutable (or don't require memory access). See also [`Base.SimdLoop.compile`](https://github.com/JuliaLang/julia/blob/79a57931a563882bac00647dc4dba1765fe4a981/base/simdloop.jl#L75-L80).
