### PR TITLE
Simplify Cat; improve inference

### DIFF
--- a/src/library.jl
+++ b/src/library.jl
@@ -146,35 +146,7 @@ end
 
 outtype(::Cat, intype) = ieltype(intype)
 
-# Inner transducer has to be started once the input is known.  That's
-# why `start` for `Cat` has to bail out immediately; i.e., it's not a
-# bug that `start(inner(rf), iresult)` is not called here:
-start(rf::R_{Cat}, result) = wrap(rf, Unseen(), result)
-complete(rf::R_{Cat}, result) = complete(inner(rf), unwrap(rf, result)[2])
-
-next(rf::R_{Cat}, result, input) =
-    wrapping(rf, result) do istate0, iresult
-        if istate0 isa Unseen
-            istate1 = start(inner(rf), iresult)
-        else
-            istate1 = istate0
-        end
-        istate2 = foldl_nocomplete(inner(rf), istate1, input)
-        istate2, istate2
-    end
-
-function combine(rf::R_{Cat}, a, b)
-    ua, ira = unwrap(rf, a)
-    ub, irb = unwrap(rf, b)
-    if ua isa Unseen
-        return wrap(rf, ub, irb)
-    elseif ub isa Unseen
-        return wrap(rf, ua, ira)
-    else
-        uc = combine(inner(rf), ua, ub)
-        return wrap(rf, uc, uc)
-    end
-end
+next(rf::R_{Cat}, result, input) = foldl_nocomplete(inner(rf), result, input)
 
 # https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/mapcat
 # https://clojuredocs.org/clojure.core/mapcat

--- a/test/test_inference.jl
+++ b/test/test_inference.jl
@@ -45,6 +45,7 @@ end
         @test_broken_inferred foldl(*, Scan(+) |> Scan(+), xs; init=1)
         @test_broken_inferred foldl(*, Scan(+) |> Map(x -> x::Int) |> Scan(+), xs)
     end
+    @test_inferred foldl(+, Cat(), [[1]])
 end
 
 @testset "collect" begin


### PR DESCRIPTION
I introduced "lazy initialization" for `Cat` in the commit 8b1ff2e99a61e92bc4af7876df76e976703316bc thinking that it was required to fix `Cat() |> DropWhile(...)`.  However, it turned out that I only needed non-completing `foldl` [1].

[1] See the simplified fix https://travis-ci.com/tkf/Transducers.jl/builds/121343261 (https://github.com/tkf/Transducers.jl/commit/82b5ee5f64a9a0faa0f89447b215e3659528e355) and expected failure when reverting the fix https://travis-ci.com/tkf/Transducers.jl/builds/121343370 (https://github.com/tkf/Transducers.jl/commit/556a4b969af4982095e0c328d249f973c7b2ceb1).
