### PR TITLE
Improve/fix Cat performance

### DIFF
--- a/benchmark/bench_cat.jl
+++ b/benchmark/bench_cat.jl
@@ -1,0 +1,14 @@
+module BenchCat
+
+using BenchmarkTools
+using Transducers
+
+itr = (y for x in 1:1000 for y in 1:x);
+
+suite = BenchmarkGroup()
+
+suite["xf"] = @benchmarkable foldl(+, eduction($itr))
+suite["base"] = @benchmarkable sum($itr)
+
+end  # module
+BenchCat.suite

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -131,7 +131,9 @@ function __foldl__(rf, init, coll)
 end
 
 @inline function _foldl_iter(rf, val::T, iter, state, counter) where T
-    while (ret = iterate(iter, state)) !== nothing
+    while true
+        ret = iterate(iter, state)
+        ret === nothing && break
         x, state = ret
         y = @next(rf, val, x)
         counter === Val(0) || y isa T ||


### PR DESCRIPTION
fix #44

```julia
julia> itr = (y for x in 1:1000 for y in 1:x);

julia> @btime foldl(+, eduction(itr))
  1.492 μs (4 allocations: 96 bytes)
167167000

julia> @btime sum(itr)
  174.592 μs (1 allocation: 16 bytes)
167167000
```

before (c6dbc4ebdeafc06d9574f4e5f854527f2e36a61c)

```julia
julia> @btime foldl(+, eduction(itr))
  194.305 μs (4 allocations: 96 bytes)
167167000
```

v0.3.0:

```julia
julia> @btime foldl(+, eduction(itr))
  19.802 μs (1496 allocations: 39.09 KiB)
167167000
```