### PR TITLE
Refactoring: make `Eduction` a subtype of `Foldable`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Transducers"
 uuid = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4-DEV"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -814,11 +814,10 @@ false
 """
 Base.foreach(eff, xform::Transducer, coll; kwargs...) =
     transduce(xform, SideEffect(eff), nothing, coll; kwargs...)
-Base.foreach(eff, ed::Eduction; kwargs...) =
-    transduce(reform(ed.rf, SideEffect(eff)), nothing, ed.coll;
-              kwargs...)
-Base.foreach(eff, reducible::Reducible; kwargs...) =
-    transduce(BottomRF(SideEffect(eff)), nothing, reducible; kwargs...)
+function Base.foreach(eff, reducible::Reducible; kwargs...)
+    xf, coll = induction(reducible)
+    return transduce(xf, SideEffect(eff), nothing, coll; kwargs...)
+end
 
 """
     ifunreduced(f, [x])


### PR DESCRIPTION
The main motivation is to make `withprogress` work without transducers.