### PR TITLE
Reexport useful functions/types from BangBang/InitialValues

### DIFF
--- a/src/Transducers.jl
+++ b/src/Transducers.jl
@@ -42,6 +42,12 @@ else
     @eval const $(Symbol("@spawn")) = $(Symbol("@async"))
 end
 
+# Some upstream APIs that are frequently used with Transducers.jl.
+# From BangBang.jl:
+export Empty, append!!, push!!
+# From InitialValue.jl:
+export Init
+
 include("showutils.jl")
 include("basics.jl")
 include("core.jl")


### PR DESCRIPTION
This way, it's easier to make downstream code forward-compatible after
moving things around across packages.

Not updating documentation yet so that it would be compatible with
older versions of Transducers.jl.