### PR TITLE
Properly setup parallel build for Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,14 @@ julia:
 env:
    global:
      - JULIA_NUM_THREADS=2
+     - COVERALLS_PARALLEL=true
 matrix:
   allow_failures:
     - julia: nightly
   fast_finish: true
 notifications:
   email: false
+  webhooks: https://coveralls.io/webhook
 
 # Only build branches via PR to avoid running CI twice.
 # https://docs.travis-ci.com/user/conditional-builds-stages-jobs


### PR DESCRIPTION
See step 4 of
https://github.com/JuliaCI/Coverage.jl/tree/v1.0.0#tracking-coverage-with-coverallsio