### PR TITLE
Revert "Use create-pull-request v2 (#164)"

### DIFF
--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -34,7 +34,7 @@ jobs:
       # https://github.com/peter-evans/create-pull-request
       # https://github.com/marketplace/actions/create-pull-request
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update */Manifest.toml
@@ -52,6 +52,7 @@ jobs:
           # https://doc.mergify.io/actions.html#commit-message-and-squash-method
           labels: no changelog
           branch: create-pull-request/pkg-update
+          branch-suffix: none
           base: master
       - name: Check output environment variable
         run: echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"


### PR DESCRIPTION
With create-pull-request v2, pkg-update.yml fails with message

    Working base branch 'create-pull-request/pkg-update' was created
    by this action.

See, e.g.,
https://github.com/tkf/Transducers.jl/commit/f355ead83998dc51359a3df695dde1b3aa3ad13c/checks?check_suite_id=407542139#step:8:46

It looks like this check is added in v2:
https://github.com/peter-evans/create-pull-request/commit/b7565b81a795750559851ac6d0c91f39ba37e636#diff-574590219ffa8e6059b434d8f8a5273cR87-R95

Let's keep using v1 for now.

This reverts commit f355ead83998dc51359a3df695dde1b3aa3ad13c.