### PR TITLE
Generic `Reduced` handling in parallel reduce

### DIFF
--- a/src/dreduce.jl
+++ b/src/dreduce.jl
@@ -71,12 +71,7 @@ function dtransduce(
     end
     # TODO: Cancel remote computation when there is a Reduced.
     results = map(fetch, futures)
-    i = findfirst(isreduced, results)
-    i === nothing || return results[i]
-    c = foldl(results) do a, b
-        combine(rf, a, b)
-    end
-    return complete(rf, c)
+    return complete(rf, combine_all(rf, results))
 end
 
 function load_me_everywhere()

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -159,7 +159,7 @@ function _reduce(ctx, rf, init, reducible::Reducible)
         a = @return_if_reduced a0
         should_abort(ctx) && return a  # slight optimization
         b = unreduced(b0)
-        b0 isa Reduced && return Reduced(combine(rf, a, b))
+        b0 isa Reduced && return reduced(combine(rf, a, b))
         return combine(rf, a, b)
     end
 end
@@ -201,7 +201,7 @@ combine_step(rf) =
     asmonoid() do a0, b0
         a = @return_if_reduced a0
         b = unreduced(b0)
-        b0 isa Reduced && return Reduced(combine(rf, a, b))
+        b0 isa Reduced && return reduced(combine(rf, a, b))
         return combine(rf, a, b)
     end
 

--- a/test/test_distributed_reduce.jl
+++ b/test/test_distributed_reduce.jl
@@ -46,6 +46,13 @@ end
     @test dcopy(Map(makerow), StructVector, 1:3, basesize = 2) == StructVector(a = 1:3)
 end
 
+@testset "TakeWhile" begin
+    coll = 1:10
+    @testset for basesize in 1:(length(coll)+1)
+        @test dcollect(TakeWhile(x -> x < 5), coll; basesize = basesize) == 1:4
+    end
+end
+
 @testset "basesize > 0" begin
     @test dcollect(Map(identity), [1]) == [1]
 end

--- a/test/test_distributed_reduce.jl
+++ b/test/test_distributed_reduce.jl
@@ -47,9 +47,13 @@ end
 end
 
 @testset "TakeWhile" begin
+    fname = gensym(:lessthan5)
+    @everywhere $fname(x) = x < 5
+    lessthan5 = getproperty(Main, fname)
+
     coll = 1:10
     @testset for basesize in 1:(length(coll)+1)
-        @test dcollect(TakeWhile(x -> x < 5), coll; basesize = basesize) == 1:4
+        @test dcollect(TakeWhile(lessthan5), coll; basesize = basesize) == 1:4
     end
 end
 

--- a/test/test_parallel_reduce.jl
+++ b/test/test_parallel_reduce.jl
@@ -120,6 +120,13 @@ end
     end
 end
 
+@testset "TakeWhile" begin
+    coll = 1:10
+    @testset for basesize in 1:(length(coll)+1)
+        @test tcollect(TakeWhile(x -> x < 5), coll; basesize = basesize) == 1:4
+    end
+end
+
 @testset "withprogress" begin
     xf = Map() do x
         x


### PR DESCRIPTION
## Commit Message
Generic `Reduced` handling in parallel reduce (#172)

Previously, `Reduced` did not have a meaningful behavior in parallel
`reduce` when the reducing function is not `right`:

    julia> tcollect(TakeWhile(x -> x < 5), 1:10; basesize=1)
    Empty{Array{T,1} where T}()

    julia> tcollect(TakeWhile(x -> x < 5), 1:10; basesize=2)
    1-element Array{Int64,1}:
     4

    julia> tcollect(TakeWhile(x -> x < 5), 1:10; basesize=4)
    2-element Array{Int64,1}:
     3
     4

    julia> tcollect(TakeWhile(x -> x < 5), 1:10; basesize=5)
    4-element Array{Int64,1}:
     1
     2
     3
     4

This PR fixes it by properly formulating how to execute the reducing
function when combined with `Reduced`.  This is done by "augmenting"
the reducing function `*`:

Given a semigroup `*(::T, ::T) :: T` where `!(Reduced <: T)`, fold
functions in Transducers.jl act on an "augmented" semigroup
`*′(::T′, ::T′) :: T′` where `T′ = Union{T, Reduced{T}}` defined by

    *′(a::Reduced, _) = a
    *′(a::T, b::Reduced) = reduced(a * unreduced(b))
    *′(a::T, b::T) = a * b

If `*` is a monoid with the identity element `e`, the "augmented"
semigroup `*′` is also a monoid with the identity element `e′`.
