### PR TITLE
tweak map_filter_iterators "lowering" in docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -113,7 +113,7 @@ would be lowered to:
 ```jldoctest manual-composition; output = false
 function map_filter_iterators(xs, init)
     ret = iterate(xs)
-    ret === nothing && return
+    ret === nothing && return init
     acc = init
     @goto filter
     local state, x
@@ -129,7 +129,6 @@ function map_filter_iterators(xs, init)
         acc += y    # +     :              :          :
     end             # :     :              :          :
     #                 + <-- imap <-------- filter <-- input
-    return acc
 end
 
 # output


### PR DESCRIPTION
Noob here, but it seems that `map_filter_iterators` should return `init` on empty collection to be equivalent to the transducer version. And the last `return acc` looks unreachable?