### PR TITLE
Workaround: at-testset is not return-safe

### DIFF
--- a/test/test_doctest.jl
+++ b/test/test_doctest.jl
@@ -7,14 +7,13 @@ using Transducers
 @testset "doctest" begin
     if lowercase(get(ENV, "JULIA_PKGEVAL", "false")) == "true"
         @info "Skipping doctests on PkgEval."
-        return
     elseif VERSION >= v"1.5-"
         @info "Skipping doctests on Julia $VERSION."
-        return
+    else
+        include("../docs/utils.jl")
+        transducers_rm_examples()
+        doctest(Transducers; manual=true)
     end
-    include("../docs/utils.jl")
-    transducers_rm_examples()
-    doctest(Transducers; manual=true)
 end
 
 end  # module


### PR DESCRIPTION
due to https://github.com/JuliaLang/julia/issues/32937
