### PR TITLE
Rename TeeZip to ZipSource and deprecate TeeZip

### DIFF
--- a/docs/src/doctests/show_rf.md
+++ b/docs/src/doctests/show_rf.md
@@ -3,7 +3,7 @@
 ```@meta
 DocTestSetup = quote
     using Transducers
-    using Transducers: Reduction, TeeZip
+    using Transducers: Reduction, ZipSource
 end
 ```
 
@@ -33,7 +33,7 @@ Reduction(
 
 ```jldoctest
 rf = Reduction(
-    TeeZip(Filter(isodd) |> Map(identity) |> TeeZip(Map(identity))),
+    ZipSource(Filter(isodd) |> Map(identity) |> ZipSource(Map(identity))),
     right,
 )
 

--- a/docs/src/doctests/show_xf.md
+++ b/docs/src/doctests/show_xf.md
@@ -3,7 +3,7 @@
 ```@meta
 DocTestSetup = quote
     using Transducers
-    using Transducers: TeeZip
+    using Transducers: ZipSource
 end
 ```
 
@@ -13,28 +13,28 @@ Map(sin) |>
     Map(cos) |>
     Map(tan)
 
-julia> TeeZip(Map(sin) |> TeeZip(Map(tan)))
-TeeZip(
+julia> ZipSource(Map(sin) |> ZipSource(Map(tan)))
+ZipSource(
     Map(sin) |>
-        TeeZip(Map(tan))
+        ZipSource(Map(tan))
 )
 
-julia> TeeZip(Map(sin) |> TeeZip(Map(tan) |> Filter(isfinite)) |> MapSplat(*))
-TeeZip(
+julia> ZipSource(Map(sin) |> ZipSource(Map(tan) |> Filter(isfinite)) |> MapSplat(*))
+ZipSource(
     Map(sin) |>
-        TeeZip(
+        ZipSource(
             Map(tan) |>
                 Filter(isfinite)
         ) |>
         MapSplat(*)
 )
 
-julia> TeeZip(Map(sin) |>
-              TeeZip(Map(tan) |> Filter(isfinite)) |>
+julia> ZipSource(Map(sin) |>
+              ZipSource(Map(tan) |> Filter(isfinite)) |>
               MapSplat(*)) |> MapSplat(+)
-TeeZip(
+ZipSource(
     Map(sin) |>
-        TeeZip(
+        ZipSource(
             Map(tan) |>
                 Filter(isfinite)
         ) |>
@@ -42,8 +42,8 @@ TeeZip(
 ) |>
     MapSplat(+)
 
-julia> TeeZip(OfType(Float64)) |> MapSplat(+)
-TeeZip(OfType(Float64)) |>
+julia> ZipSource(OfType(Float64)) |> MapSplat(+)
+ZipSource(OfType(Float64)) |>
     MapSplat(+)
 ```
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -46,7 +46,7 @@ Filter = Transducers.is_transducer_type
 ### Experimental transducers
 
 ```@docs
-Transducers.TeeZip
+Transducers.ZipSource
 Transducers.GetIndex
 Transducers.SetIndex
 Transducers.Inject

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,6 +1,7 @@
 using Base: @deprecate
 
 @deprecate Distinct() Unique()
+@deprecate TeeZip(xf) ZipSource(xf) false
 
 # It wasn't a public API but to play on the safe side:
 @deprecate induction(itr) extract_transducer(itr) false

--- a/src/lister.jl
+++ b/src/lister.jl
@@ -5,7 +5,7 @@ _unexported_public_api = (
     # Experimental
     channel_unordered,
     append_unordered!,
-    TeeZip,
+    ZipSource,
     GetIndex,
     SetIndex,
     Inject,

--- a/src/processes.jl
+++ b/src/processes.jl
@@ -770,7 +770,7 @@ function _prepare_map(xf, dest, src, simd)
     indices = eachindex(dest, src)
 
     rf = reducingfunction(
-        TeeZip(GetIndex{true}(src) |> xf) |> SetIndex{true}(dest),
+        ZipSource(GetIndex{true}(src) |> xf) |> SetIndex{true}(dest),
         (::Vararg) -> nothing,
         simd = simd)
 

--- a/test/__test_ir.jl
+++ b/test/__test_ir.jl
@@ -70,7 +70,7 @@ unsafe_setter(ys) =
 
     params = [
         :Enumerate => xf_double |> Enumerate(),
-        :TeeZip => xf_double |> Transducers.TeeZip(Count()) |> Map(reverse),
+        :ZipSource => xf_double |> Transducers.ZipSource(Count()) |> Map(reverse),
         #= Zip was working before...
         :Zip => Zip(Count(), xf_double),
         =#

--- a/test/preamble.jl
+++ b/test/preamble.jl
@@ -4,7 +4,7 @@ using SparseArrays: issparse, sparse
 using Statistics: mean
 using Transducers
 using Transducers: Transducer, simple_transduce, Reduced, isexpansive,
-    TeeZip, GetIndex, SetIndex, Inject, @~, IdentityTransducer,
+    ZipSource, GetIndex, SetIndex, Inject, @~, IdentityTransducer,
     EmptyResultError, IdentityNotDefinedError, AbortIf, @next
 using InitialValues: Init
 using Logging: NullLogger, with_logger

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -36,7 +36,7 @@ end
     @testset for xf in [
             Count(),
             Map(identity) |> Count(),
-            TeeZip(Map(identity) |> Count()),
+            ZipSource(Map(identity) |> Count()),
             ]
         rf = eduction(xf, 1:1).rf
         @test rf === reform(rf, f)

--- a/test/test_inference.jl
+++ b/test/test_inference.jl
@@ -35,7 +35,7 @@ end
         @test_inferred foldl(+, TakeLast(1), xs)
         @test_inferred foldl(+, PartitionBy(identity) |> Map(first), xs)
         @test_inferred foldl(+, Unique(), xs)
-        @test_inferred foldl(right, TeeZip(Filter(isodd) |> Map(inc)), xs)
+        @test_inferred foldl(right, ZipSource(Filter(isodd) |> Map(inc)), xs)
 
         # Nested stateful transducers.  (The ones with `right` and
         # `Map(x -> x::Int)` actually succeeded in some REPL

--- a/test/test_library.jl
+++ b/test/test_library.jl
@@ -100,25 +100,25 @@ end
     end
 end
 
-@testset "TeeZip" begin
+@testset "ZipSource" begin
     @testset for xs in iterator_variants(1:5)
-        @test collect(TeeZip(Filter(isodd) |> Map(inc)), xs) ==
+        @test collect(ZipSource(Filter(isodd) |> Map(inc)), xs) ==
             collect(zip(1:2:5, 2:2:6))
     end
 
-    xf = Map(inc) |> TeeZip(Filter(isodd)) |> Map(first)
+    xf = Map(inc) |> ZipSource(Filter(isodd)) |> Map(first)
     @testset for xs in iterator_variants(1:6)
         @test collect(xf, xs) == 3:2:7
     end
 
     @testset "Combination with stateful transducers" begin
         @testset for xs in iterator_variants(2:2:6)
-            @test collect(TeeZip(Map(identity)) |> Count(), xs) == 1:3
-            @test collect(TeeZip(Count()) |> Count(), xs) == 1:3
-            @test collect(Count() |> TeeZip(Map(x -> x + 10)), xs) ==
+            @test collect(ZipSource(Map(identity)) |> Count(), xs) == 1:3
+            @test collect(ZipSource(Count()) |> Count(), xs) == 1:3
+            @test collect(Count() |> ZipSource(Map(x -> x + 10)), xs) ==
                 collect(zip(1:3, (1:3) .+ 10))
             @test collect(
-                Enumerate() |> TeeZip(Map(x -> x[end] + 10)) |> Enumerate(),
+                Enumerate() |> ZipSource(Map(x -> x[end] + 10)) |> Enumerate(),
                 xs) == [
                     (1, ((1, 2), 12))
                     (2, ((2, 4), 14))
@@ -136,17 +136,17 @@ end
         end
     end
 
-    @testset "Nested TeeZip" begin
+    @testset "Nested ZipSource" begin
         @testset for xs in iterator_variants(1:5)
-            @test collect(TeeZip(Filter(isodd) |>
+            @test collect(ZipSource(Filter(isodd) |>
                                  Map(inc) |>
-                                 TeeZip(Map(inc))),
+                                 ZipSource(Map(inc))),
                           xs) == [
                     (1, (2, 3)),
                     (3, (4, 5)),
                     (5, (6, 7)),
                 ]
-            @test collect(TeeZip(TeeZip(Map(inc))), xs) isa Vector
+            @test collect(ZipSource(ZipSource(Map(inc))), xs) isa Vector
         end
     end
 end

--- a/test/test_processes.jl
+++ b/test/test_processes.jl
@@ -225,17 +225,17 @@ end
     # testing Transducer(::Eduction) which calls Transducer(::Reduction)
     @testset for xf in [
             Map(sin),
-            TeeZip(Filter(isfinite) |> Map(tan)),
-            Map(sin) |> TeeZip(Filter(isfinite) |> Map(tan)) |>
+            ZipSource(Filter(isfinite) |> Map(tan)),
+            Map(sin) |> ZipSource(Filter(isfinite) |> Map(tan)) |>
                 Map(cos),
-            TeeZip(Map(sin) |> TeeZip(Map(tan))),
-            TeeZip(TeeZip(Map(tan)) |> Map(identity)),
-            TeeZip(Map(sin) |> TeeZip(Map(tan)) |> Map(identity)),
-            Map(cos) |> TeeZip(Map(sin) |> TeeZip(Map(tan)) |> Map(identity)),
+            ZipSource(Map(sin) |> ZipSource(Map(tan))),
+            ZipSource(ZipSource(Map(tan)) |> Map(identity)),
+            ZipSource(Map(sin) |> ZipSource(Map(tan)) |> Map(identity)),
+            Map(cos) |> ZipSource(Map(sin) |> ZipSource(Map(tan)) |> Map(identity)),
             Map(cos) |>
-                TeeZip(Map(sin) |> TeeZip(Map(tan)) |> Map(identity)) |>
+                ZipSource(Map(sin) |> ZipSource(Map(tan)) |> Map(identity)) |>
                 Map(first),
-            TeeZip(TeeZip(Map(tan))),
+            ZipSource(ZipSource(Map(tan))),
             ]
         @test Transducer(eduction(xf, 1:1)) === xf
     end
@@ -249,7 +249,7 @@ end
     ]
     @testset for xf in expansives
         @test isexpansive(xf)
-        @test isexpansive(TeeZip(xf))
+        @test isexpansive(ZipSource(xf))
     end
     nonexpansives = [
         Map(identity)
@@ -257,7 +257,7 @@ end
     ]
     @testset for xf in nonexpansives
         @test !isexpansive(xf)
-        @test !isexpansive(TeeZip(xf))
+        @test !isexpansive(ZipSource(xf))
     end
 end
 

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -14,15 +14,15 @@ xforms = [
     Map(sin),
     Filter(isfinite),
     Scan(*),
-    TeeZip(Filter(isfinite)),
-    TeeZip(Filter(isfinite) |> Map(sin)),
-    TeeZip(Filter(isfinite) |> Map(sin)) |> Map(sum),
-    let xf = TeeZip(Filter(isfinite) |> Map(sin))
+    ZipSource(Filter(isfinite)),
+    ZipSource(Filter(isfinite) |> Map(sin)),
+    ZipSource(Filter(isfinite) |> Map(sin)) |> Map(sum),
+    let xf = ZipSource(Filter(isfinite) |> Map(sin))
         xf |> Map(sum) |> xf
     end,
     let xf = Map(first) |> Map(last)
-        xf = TeeZip(TeeZip(xf) |> Map(identity)) |> xf
-        xf |> TeeZip(xf) |> xf
+        xf = ZipSource(ZipSource(xf) |> Map(identity)) |> xf
+        xf |> ZipSource(xf) |> xf
     end,
     # Zip(Map(sin), Map(cos), Map(tan)) |> Map(prod),
 ]


### PR DESCRIPTION
Currently what is called `Zip` should probably be called `TeeZip`.
Deprecating current `TeeZip` so that the name can be used for `Zip`
in the next breaking change.