### PR TITLE
Fix `ThreadsX.foreach(f, withprogress(...))`

### DIFF
--- a/src/progress.jl
+++ b/src/progress.jl
@@ -59,6 +59,11 @@ struct ProgressLoggingFoldable{T} <: Foldable
     interval::Float64
 end
 
+Base.IteratorSize(::Type{ProgressLoggingFoldable{T}}) where {T} = Base.IteratorSize(T)
+Base.IteratorEltype(::Type{ProgressLoggingFoldable{T}}) where {T} = Base.IteratorEltype(T)
+Base.length(foldable::ProgressLoggingFoldable) = length(foldable.foldable)
+Base.eltype(::Type{ProgressLoggingFoldable{T}}) where {T} = eltype(T)
+
 # Use Juno/Atom-compatible log-level.  See:
 # https://github.com/JunoLab/Atom.jl/blob/v0.11.1/src/progress.jl#L75-L76
 const PROGRESSLEVEL = LogLevel(-1)

--- a/test/test_withprogress.jl
+++ b/test/test_withprogress.jl
@@ -1,0 +1,11 @@
+module TestWithprogress
+include("preamble.jl")
+
+@testset "traits" begin
+    @test Base.IteratorSize(withprogress(1:10)) == Base.HasShape{1}()
+    @test length(withprogress(1:10)) == 10
+    @test Base.IteratorEltype(withprogress(1:10)) == Base.HasEltype()
+    @test eltype(withprogress(1:10)) == Int
+end
+
+end  # module


### PR DESCRIPTION
`length(withprogress(...))` has to be defined.