### PR TITLE
Inline (almost) all `next` methods

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -871,7 +871,7 @@ function _getoutput(xf, x)
 end
 
 _real_state_type(T) = T
-_real_state_type(::Type{Union{T, _FakeState}}) where T = T
+_real_state_type(::Type{Union{T, _FakeState}}) where {T} = @isdefined(T) ? T : Any
 
 
 """


### PR DESCRIPTION
## Commit Message
Inline (almost) all `next` methods (#285)

`next` should probably be `@inline`d always. See also #282.

`Zip`-related methods are excluded since they can be too much work for
the compiler.  `next` for `TCat` is also excluded since there is not
much benefit for doing this.
